### PR TITLE
feat: Add GitHub Action to build portable Privoxy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: Build Portable Privoxy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install autoconf automake pcre
+
+      - name: Install dependencies on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y autoconf automake libpcre3-dev
+
+      - name: Download Privoxy source
+        run: |
+          PRIVPROXY_VERSION="3.0.34" # Specify a stable Privoxy version
+          wget "https://www.privoxy.org/sf-download-mirror/Sources/${PRIVPROXY_VERSION}%20%28stable%29%20src.tar.gz" -O privoxy.tar.gz
+          tar -xzf privoxy.tar.gz
+          mv privoxy-${PRIVPROXY_VERSION} privoxy-src
+          cd privoxy-src
+
+      - name: Configure and compile Privoxy
+        run: |
+          cd privoxy-src
+          autoheader
+          autoconf
+          ./configure
+          make
+          # Optional: make check (if you want to run tests, might need additional dependencies)
+
+      - name: Modify Privoxy configuration
+        run: |
+          cd privoxy-src # Ensure we are in the correct directory where the default config is
+          cp config default.config # Create a working copy
+          # Use sed to change the listen-address.
+          # For macOS, sed requires an extension for in-place editing backup.
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            sed -i '.bak' 's/^listen-address  127.0.0.1:8118/listen-address  0.0.0.0:8118/' default.config
+            sed -i '.bak' 's/^listen-address  \[::1\]:8118/#listen-address  \[::1\]:8118/' default.config # Also disable IPv6 localhost
+          else
+            sed -i 's/^listen-address  127.0.0.1:8118/listen-address  0.0.0.0:8118/' default.config
+            sed -i 's/^listen-address  \[::1\]:8118/#listen-address  \[::1\]:8118/' default.config # Also disable IPv6 localhost
+          fi
+          echo "Verifying config modification:"
+          grep "listen-address  0.0.0.0:8118" default.config
+
+      - name: Create packaging directory
+        run: |
+          mkdir privoxy-package
+          cd privoxy-src
+          cp privoxy ../privoxy-package/
+          cp default.config ../privoxy-package/
+          # For Linux, also create a simple launch script
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo '#!/bin/bash' > ../privoxy-package/start-privoxy.sh
+            echo 'DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"' >> ../privoxy-package/start-privoxy.sh
+            echo '$DIR/privoxy $DIR/default.config' >> ../privoxy-package/start-privoxy.sh
+            chmod +x ../privoxy-package/start-privoxy.sh
+          fi
+          cd .. # Back to GITHUB_WORKSPACE
+
+      - name: Package Privoxy for macOS (DMG)
+        if: runner.os == 'macOS'
+        run: |
+          cd privoxy-package
+          hdiutil create -fs HFS+ -volname "Privoxy" -srcfolder . privoxy_macOS.dmg
+          cd ..
+
+      - name: Package Privoxy for Linux (Tarball)
+        if: runner.os == 'Linux'
+        run: |
+          cd privoxy-package
+          tar -czvf privoxy_linux.tar.gz .
+          cd ..
+
+      - name: Upload Privoxy artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: privoxy-portable-${{ matrix.os }}
+          path: |
+            privoxy-package/privoxy_macOS.dmg
+            privoxy-package/privoxy_linux.tar.gz
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# privoxy-portable
+# Portable Privoxy Builder
+
+This repository automatically builds portable versions of Privoxy for macOS and Linux using GitHub Actions.
+
+The Privoxy configuration is modified to listen on `0.0.0.0:8118`, allowing devices on your local network to use it as a proxy.
+
+## Downloads
+
+You can download the latest portable versions from the **Actions** tab of this repository:
+1. Go to the [Actions tab](https://github.com/[your-github-username]/[your-repo-name]/actions). (Replace `[your-github-username]/[your-repo-name]` with the actual path).
+2. Click on the latest successful workflow run for the 'Build Portable Privoxy' workflow.
+3. Under the "Artifacts" section, you will find:
+    - `privoxy-portable-macos-latest`: A DMG file for macOS.
+    - `privoxy-portable-ubuntu-latest`: A `.tar.gz` file for Linux.
+
+## How to Use
+
+### macOS (DMG)
+
+1.  Download `privoxy-portable-macos-latest.dmg`.
+2.  Open the DMG file.
+3.  Drag the `Privoxy` application (or folder containing `privoxy` and `default.config`) to your Applications folder or any other location.
+4.  Run Privoxy. It will use the included `default.config`.
+    (Note: Depending on how the DMG is structured by the build, you might need to navigate into a folder within the DMG and run the `privoxy` executable from a terminal, or it might be a more complete app bundle if we enhance the macOS packaging later. For now, it will likely be the `privoxy` executable and `default.config`.)
+
+### Linux (Tarball)
+
+1.  Download `privoxy-portable-ubuntu-latest.tar.gz`.
+2.  Extract the archive: `tar -xzf privoxy-portable-ubuntu-latest.tar.gz`
+3.  This will create a directory (e.g., `privoxy-package`). Navigate into it: `cd privoxy-package`
+4.  Run the launch script: `./start-privoxy.sh`
+    This script starts Privoxy using the included `default.config` file.
+
+## Configuration
+
+The included `default.config` file has the `listen-address` set to `0.0.0.0:8118`. This means Privoxy will accept connections from any IP address on your local network.
+
+**Security Note:** Be aware that allowing connections from `0.0.0.0` makes Privoxy accessible to any device on your network. Ensure your network is secure. If you only need to access Privoxy from the machine it's running on, you can change the `listen-address` back to `127.0.0.1:8118` in the `default.config` file.
+
+## Building Locally (Optional)
+
+If you want to build Privoxy locally using the same steps as the GitHub Actions workflow:
+1. Clone this repository.
+2. Ensure you have the necessary build dependencies installed for your OS (see `.github/workflows/build.yml` for details: `autoconf`, `automake`, `pcre` for macOS; `autoconf`, `automake`, `libpcre3-dev` for Linux).
+3. Follow the compilation, configuration modification, and packaging steps outlined in the `.github/workflows/build.yml` file.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the building of portable Privoxy versions for macOS and Linux.

The workflow performs the following:
- Sets up build environments for macOS-latest and ubuntu-latest.
- Installs necessary dependencies (autoconf, automake, pcre).
- Downloads and compiles Privoxy from source (version 3.0.34).
- Modifies the default Privoxy configuration to change the listen-address from 127.0.0.1:8118 to 0.0.0.0:8118. This allows other devices on your local network to use Privoxy. The IPv6 localhost listener is also disabled.
- Packages the compiled binary and modified configuration:
    - For macOS: Creates a DMG file.
    - For Linux: Creates a .tar.gz archive containing the binary, config, and a simple start-privoxy.sh launch script.
- Uploads the generated DMG and tar.gz files as build artifacts.

Additionally, a README.md file has been added to provide you with:
- Instructions on how to download the artifacts from GitHub Actions.
- Basic usage steps for both macOS and Linux versions.
- Information about the configuration modification and a security note.
- Guidance for building locally.